### PR TITLE
Fixes #51 (ctrl-c bug)

### DIFF
--- a/autoload/sneak/streak.vim
+++ b/autoload/sneak/streak.vim
@@ -105,7 +105,7 @@ func! s:do_streak(s, st)
   if choice == "\<Tab>" && overflow[0] > 0
     call cursor(overflow[0], overflow[1])
     return 1 "overflow => decorate next N matches
-  elseif -1 != index(["\<Esc>", "\<Space>", "\<CR>"], choice)
+  elseif -1 != index(["\<Esc>", "\<C-c>", "\<Space>", "\<CR>"], choice)
     return 0 "exit streak-mode.
   elseif mappedto =~# '<Plug>V\?Sneak.\?\(Fwd\|Next\|Forward\)'
     call sneak#rpt(v, 1, 0)


### PR DESCRIPTION
Adds ctrl-c to the list of characters that exit streak mode without a
fall through to vim. That fall through is most likely the cause of the weird state you encountered in #51. Not worth thinking about that problem, ctrl-c causes all kinds of havoc when plugins, autocmds etc are used.

Anyway, all is fine when ctrl-c is added to this list, I assume that's what you intended to do anyway :)
