### PR TITLE
Add an option to support optional regex input

### DIFF
--- a/autoload/sneak/search.vim
+++ b/autoload/sneak/search.vim
@@ -8,7 +8,8 @@ func! sneak#search#new()
     " search pattern modifiers (case-sensitivity, magic)
     let self.prefix = sneak#search#get_cs(a:input, g:sneak#opt.use_ic_scs).'\V'
     " the escaped user input to search for
-    let self.search = escape(a:input, '"\')
+    let self.search = a:input =~? '^\\[vm].' ?
+          \ escape(a:input, '"').'\V' : escape(a:input, '"\')
     " example: highlight string 'ab' after line 42, column 5 
     "          matchadd('foo', 'ab\%>42l\%5c', 1)
     let self.match_pattern = ''


### PR DESCRIPTION
Fix #104. This should support more flexibility in customisation. With
this option enabled, input text not matching '^\[vVmM].' are still
treated literal.
