### PR TITLE
[RFC] Add option for streak mode with `<Plug>Sneak_f` etc

### DIFF
--- a/doc/sneak.txt
+++ b/doc/sneak.txt
@@ -272,6 +272,11 @@ to enter streak-mode), create a mapping to <Plug>(SneakStreak). For example:
     nmap s <Plug>(SneakStreak)
     nmap S <Plug>(SneakStreakBackward)
 <
+To force streak-mode with the predefined 1-char 'enhanced f' and 'enhanced t'
+maps (<Plug>Sneak_f, <Plug>Sneak_F, <Plug>Sneak_t and <Plug>Sneak_T):
+>
+    let g:sneak#streak = 2
+<
 Streak-mode features:
 
     - automatically jumps to the first match
@@ -363,7 +368,11 @@ g:sneak#streak = 0
 
     0 : Disable |sneak-streak-mode|.
 
-    1 : Enable |sneak-streak-mode| if the Vim |+conceal| feature is available.
+    1 : Enable (smart) |sneak-streak-mode| if the Vim |+conceal| feature is
+        available.
+
+    2 : Force |sneak-streak-mode| with "extended f/t" maps, if the Vim
+        |+conceal| feature is available.
 
 g:sneak#target_labels = "asdfghjkl;qwertyuiopzxcvbnm/ASDFGHJKL:QWERTYUIOPZXCVBNM?"
 

--- a/doc/sneak.txt
+++ b/doc/sneak.txt
@@ -5,17 +5,17 @@
 ==============================================================================
 1. Overview                                                            *sneak*
 
-Sneak provides a way to move quickly and precisely to locations that would 
-be awkward to reach with built-in Vim motions. 
+Sneak provides a way to move quickly and precisely to locations that would
+be awkward to reach with built-in Vim motions.
 
 Sneak is invoked with s (sneak forward) or S (sneak backwards), followed by
 exactly two characters:
 
     s{char}{char}
 
-Thus, you can often reach a target with only 3 keystrokes. Sneak always moves 
+Thus, you can often reach a target with only 3 keystrokes. Sneak always moves
 immediately to the first {char}{char} match. Additional matches are
-highlighted, and you can reach them by pressing ; (similar to the built-in 
+highlighted, and you can reach them by pressing ; (similar to the built-in
 behavior for |f| and |t|).
 
 Sneak has a few other features, but above all, Sneak tries to get out of your
@@ -71,7 +71,7 @@ Sneak default NORMAL-mode mappings:
     {range}S{char}{char}     | Invoke backwards |sneak-vertical-scope|
     {operator}z{char}{char}  | Perform {operator} from the cursor to the next
                              | occurrence of {char}{char}
-    {operator}Z{char}{char}  | Perform {operator} from the cursor to the 
+    {operator}Z{char}{char}  | Perform {operator} from the cursor to the
                              | previous occurrence of {char}{char}
 
     NOTE: s and S go to the next/previous match only immediately after
@@ -239,8 +239,8 @@ Repeat the operation with dot: |.|
 ------------------------------------------------------------------------------
 3.5 Vertical Scope                                      *sneak-vertical-scope*
 
-Sneak has a unique feature called "vertical scope" search. This is invoked by 
-prefixing a normal Sneak search (`s` or `S`) with a [count]. In that case, 
+Sneak has a unique feature called "vertical scope" search. This is invoked by
+prefixing a normal Sneak search (`s` or `S`) with a [count]. In that case,
 the search is restricted to a column having a width of 2× the [count].
 
 |sneak-vertical-scope| never invokes |sneak-streak-mode|.
@@ -316,7 +316,7 @@ Following is a list of Sneak options with their default values.
 g:sneak#f_reset = 1
 g:sneak#t_reset = 1
 
-        Note: if you have mapped f (or t) to a |sneak-mappings| then the 
+        Note: if you have mapped f (or t) to a |sneak-mappings| then the
         default is 0.
 
     0 : Pressing |f| (or |t|) will NOT clear the last Sneak search. So you could

--- a/doc/sneak.txt
+++ b/doc/sneak.txt
@@ -263,8 +263,8 @@ To enable "passive" or "smart" streak-mode:                   *g:sneak#streak*
 >
     let g:sneak#streak = 1
 >
-With this setting, sneak with automatically enter streak-mode _only_ if there
-are ≥2 visible (on-screen) matches
+With this setting, sneak will automatically enter streak-mode _only_ if there
+are ≥2 visible (on-screen) matches.
 
 To force streak-mode always (instead of passively letting Sneak decide when
 to enter streak-mode), create a mapping to <Plug>(SneakStreak). For example:

--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -306,20 +306,20 @@ if g:sneak#opt.textobject_z
 endif
 
 " 1-char 'enhanced f' sneak
-nnoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap('', 1, 0, 1, g:sneak#opt.streak>1)<cr>
-nnoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap('', 1, 1, 1, g:sneak#opt.streak>1)<cr>
-xnoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap(visualmode(), 1, 0, 1, g:sneak#opt.streak>1)<cr>
-xnoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap(visualmode(), 1, 1, 1, g:sneak#opt.streak>1)<cr>
-onoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap(v:operator, 1, 0, 1, g:sneak#opt.streak>1)<cr>
-onoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap(v:operator, 1, 1, 1, g:sneak#opt.streak>1)<cr>
+nnoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap('', 1, 0, 1, g:sneak#opt.streak)<cr>
+nnoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap('', 1, 1, 1, g:sneak#opt.streak)<cr>
+xnoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap(visualmode(), 1, 0, 1, g:sneak#opt.streak)<cr>
+xnoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap(visualmode(), 1, 1, 1, g:sneak#opt.streak)<cr>
+onoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap(v:operator, 1, 0, 1, g:sneak#opt.streak)<cr>
+onoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap(v:operator, 1, 1, 1, g:sneak#opt.streak)<cr>
 
 " 1-char 'enhanced t' sneak
-nnoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap('', 1, 0, 0, g:sneak#opt.streak>1)<cr>
-nnoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap('', 1, 1, 0, g:sneak#opt.streak>1)<cr>
-xnoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap(visualmode(), 1, 0, 0, g:sneak#opt.streak>1)<cr>
-xnoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap(visualmode(), 1, 1, 0, g:sneak#opt.streak>1)<cr>
-onoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap(v:operator, 1, 0, 0, g:sneak#opt.streak>1)<cr>
-onoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap(v:operator, 1, 1, 0, g:sneak#opt.streak>1)<cr>
+nnoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap('', 1, 0, 0, g:sneak#opt.streak)<cr>
+nnoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap('', 1, 1, 0, g:sneak#opt.streak)<cr>
+xnoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap(visualmode(), 1, 0, 0, g:sneak#opt.streak)<cr>
+xnoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap(visualmode(), 1, 1, 0, g:sneak#opt.streak)<cr>
+onoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap(v:operator, 1, 0, 0, g:sneak#opt.streak)<cr>
+onoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap(v:operator, 1, 1, 0, g:sneak#opt.streak)<cr>
 
 nnoremap <silent> <Plug>(SneakStreak)         :<c-u>call sneak#wrap('', 2, 0, 2, 2)<cr>
 nnoremap <silent> <Plug>(SneakStreakBackward) :<c-u>call sneak#wrap('', 2, 1, 2, 2)<cr>

--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -24,8 +24,6 @@ func! sneak#init()
       \ ,'use_ic_scs'   : get(g:, 'sneak#use_ic_scs', 0)
       \ ,'map_netrw'    : get(g:, 'sneak#map_netrw', 1)
       \ ,'streak'       : get(g:, 'sneak#streak', 0) && (v:version >= 703) && has("conceal")
-      \ ,'streak_with_f': get(g:, 'sneak#streak_with_f', 0)
-      \ ,'streak_with_t': get(g:, 'sneak#streak_with_t', 0)
       \ }
 
   for k in ['f', 't'] "if user mapped f/t to Sneak, then disable f/t reset.
@@ -196,7 +194,7 @@ func! sneak#to(op, input, inputlen, count, repeatmotion, reverse, inclusive, str
   "let user deactivate with <esc>
   if maparg('<esc>', 'n') ==# ""|nmap <silent> <esc> :<c-u>call sneak#cancel()<cr><esc>|endif
 
-  "enter streak-mode iff there are >=2 _additional_ on-screen matches.
+  "enter streak-mode if there are >=2 _additional_ on-screen matches.
   let target = (2 == a:streak || (a:streak && g:sneak#opt.streak)) && !max(bounds) && s.hasmatches(2)
         \ ? sneak#streak#to(s, is_v, a:reverse): ""
 
@@ -308,20 +306,20 @@ if g:sneak#opt.textobject_z
 endif
 
 " 1-char 'enhanced f' sneak
-nnoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap('', 1, 0, 1, g:sneak#opt.streak_with_f)<cr>
-nnoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap('', 1, 1, 1, g:sneak#opt.streak_with_f)<cr>
-xnoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap(visualmode(), 1, 0, 1, g:sneak#opt.streak_with_f)<cr>
-xnoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap(visualmode(), 1, 1, 1, g:sneak#opt.streak_with_f)<cr>
-onoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap(v:operator, 1, 0, 1, g:sneak#opt.streak_with_f)<cr>
-onoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap(v:operator, 1, 1, 1, g:sneak#opt.streak_with_f)<cr>
+nnoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap('', 1, 0, 1, g:sneak#opt.streak>1)<cr>
+nnoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap('', 1, 1, 1, g:sneak#opt.streak>1)<cr>
+xnoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap(visualmode(), 1, 0, 1, g:sneak#opt.streak>1)<cr>
+xnoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap(visualmode(), 1, 1, 1, g:sneak#opt.streak>1)<cr>
+onoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap(v:operator, 1, 0, 1, g:sneak#opt.streak>1)<cr>
+onoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap(v:operator, 1, 1, 1, g:sneak#opt.streak>1)<cr>
 
 " 1-char 'enhanced t' sneak
-nnoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap('', 1, 0, 0, g:sneak#opt.streak_with_t)<cr>
-nnoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap('', 1, 1, 0, g:sneak#opt.streak_with_t)<cr>
-xnoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap(visualmode(), 1, 0, 0, g:sneak#opt.streak_with_t)<cr>
-xnoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap(visualmode(), 1, 1, 0, g:sneak#opt.streak_with_t)<cr>
-onoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap(v:operator, 1, 0, 0, g:sneak#opt.streak_with_t)<cr>
-onoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap(v:operator, 1, 1, 0, g:sneak#opt.streak_with_t)<cr>
+nnoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap('', 1, 0, 0, g:sneak#opt.streak>1)<cr>
+nnoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap('', 1, 1, 0, g:sneak#opt.streak>1)<cr>
+xnoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap(visualmode(), 1, 0, 0, g:sneak#opt.streak>1)<cr>
+xnoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap(visualmode(), 1, 1, 0, g:sneak#opt.streak>1)<cr>
+onoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap(v:operator, 1, 0, 0, g:sneak#opt.streak>1)<cr>
+onoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap(v:operator, 1, 1, 0, g:sneak#opt.streak>1)<cr>
 
 nnoremap <silent> <Plug>(SneakStreak)         :<c-u>call sneak#wrap('', 2, 0, 2, 2)<cr>
 nnoremap <silent> <Plug>(SneakStreakBackward) :<c-u>call sneak#wrap('', 2, 1, 2, 2)<cr>

--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -194,7 +194,7 @@ func! sneak#to(op, input, inputlen, count, repeatmotion, reverse, inclusive, str
   "let user deactivate with <esc>
   if maparg('<esc>', 'n') ==# ""|nmap <silent> <esc> :<c-u>call sneak#cancel()<cr><esc>|endif
 
-  "enter streak-mode if there are >=2 _additional_ on-screen matches.
+  "enter streak-mode iff there are >=2 _additional_ on-screen matches.
   let target = (2 == a:streak || (a:streak && g:sneak#opt.streak)) && !max(bounds) && s.hasmatches(2)
         \ ? sneak#streak#to(s, is_v, a:reverse): ""
 

--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -24,6 +24,8 @@ func! sneak#init()
       \ ,'use_ic_scs'   : get(g:, 'sneak#use_ic_scs', 0)
       \ ,'map_netrw'    : get(g:, 'sneak#map_netrw', 1)
       \ ,'streak'       : get(g:, 'sneak#streak', 0) && (v:version >= 703) && has("conceal")
+      \ ,'streak_with_f': get(g:, 'sneak#streak_with_f', 0)
+      \ ,'streak_with_t': get(g:, 'sneak#streak_with_t', 0)
       \ }
 
   for k in ['f', 't'] "if user mapped f/t to Sneak, then disable f/t reset.
@@ -306,20 +308,20 @@ if g:sneak#opt.textobject_z
 endif
 
 " 1-char 'enhanced f' sneak
-nnoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap('', 1, 0, 1, 0)<cr>
-nnoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap('', 1, 1, 1, 0)<cr>
-xnoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap(visualmode(), 1, 0, 1, 0)<cr>
-xnoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap(visualmode(), 1, 1, 1, 0)<cr>
-onoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap(v:operator, 1, 0, 1, 0)<cr>
-onoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap(v:operator, 1, 1, 1, 0)<cr>
+nnoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap('', 1, 0, 1, g:sneak#opt.streak_with_f)<cr>
+nnoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap('', 1, 1, 1, g:sneak#opt.streak_with_f)<cr>
+xnoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap(visualmode(), 1, 0, 1, g:sneak#opt.streak_with_f)<cr>
+xnoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap(visualmode(), 1, 1, 1, g:sneak#opt.streak_with_f)<cr>
+onoremap <silent> <Plug>Sneak_f :<c-u>call sneak#wrap(v:operator, 1, 0, 1, g:sneak#opt.streak_with_f)<cr>
+onoremap <silent> <Plug>Sneak_F :<c-u>call sneak#wrap(v:operator, 1, 1, 1, g:sneak#opt.streak_with_f)<cr>
 
 " 1-char 'enhanced t' sneak
-nnoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap('', 1, 0, 0, 0)<cr>
-nnoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap('', 1, 1, 0, 0)<cr>
-xnoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap(visualmode(), 1, 0, 0, 0)<cr>
-xnoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap(visualmode(), 1, 1, 0, 0)<cr>
-onoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap(v:operator, 1, 0, 0, 0)<cr>
-onoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap(v:operator, 1, 1, 0, 0)<cr>
+nnoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap('', 1, 0, 0, g:sneak#opt.streak_with_t)<cr>
+nnoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap('', 1, 1, 0, g:sneak#opt.streak_with_t)<cr>
+xnoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap(visualmode(), 1, 0, 0, g:sneak#opt.streak_with_t)<cr>
+xnoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap(visualmode(), 1, 1, 0, g:sneak#opt.streak_with_t)<cr>
+onoremap <silent> <Plug>Sneak_t :<c-u>call sneak#wrap(v:operator, 1, 0, 0, g:sneak#opt.streak_with_t)<cr>
+onoremap <silent> <Plug>Sneak_T :<c-u>call sneak#wrap(v:operator, 1, 1, 0, g:sneak#opt.streak_with_t)<cr>
 
 nnoremap <silent> <Plug>(SneakStreak)         :<c-u>call sneak#wrap('', 2, 0, 2, 2)<cr>
 nnoremap <silent> <Plug>(SneakStreakBackward) :<c-u>call sneak#wrap('', 2, 1, 2, 2)<cr>


### PR DESCRIPTION
This allows use (and force) streak mode with `f` / `t` etc:

```
let g:sneak#streak=1
let g:sneak#streak_with_f=2
let g:sneak#streak_with_t=2
```

This PR misses documentation and tests, because it's meant to discuss this first.

I could also imagine to make `g:sneak#streak=2` trigger this.
