### PR TITLE
Return empty string instead of `0` for the <expr> cancel mapping

### DIFF
--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -50,6 +50,7 @@ func! sneak#cancel()
   if maparg('<esc>', 'n') =~# 'sneak#cancel' "teardown temporary <esc> mapping
     silent! unmap <esc>
   endif
+  return ''
 endf
 
 " convenience wrapper for key bindings/mappings


### PR DESCRIPTION
functions without `return` statements return `0`, so if you call them
by `<expr>` mappings, I guess you know what will be happen ;)

ref #129
