### PR TITLE
[RFC] SneakNext and SneakPrevious Mappings Preserve Search Direction

### DIFF
--- a/doc/sneak.txt
+++ b/doc/sneak.txt
@@ -349,7 +349,7 @@ g:sneak#s_next = 0
         persists until you move the cursor.
         Note: You can still use |;| and |,| as usual.
 
-g:sneak#preserve_dir = 0
+g:sneak#absolute_dir = 0
 
     0 : Repeating a sneak using |;| or |,| moves to the next or previous match.
 

--- a/doc/sneak.txt
+++ b/doc/sneak.txt
@@ -349,6 +349,15 @@ g:sneak#s_next = 0
         persists until you move the cursor.
         Note: You can still use |;| and |,| as usual.
 
+g:sneak#preserve_dir = 0
+
+    0 : Repeating a sneak using |;| or |,| moves to the next or previous match.
+
+    1 : Repeating a sneak using |;| or |,| always moves the cursor forwards or
+        backwards respectively.
+        Note: When |sneak-clever-s| is enabled, "s" and "S" behave the same as
+        |;| and |,|.
+
 g:sneak#textobject_z = 1
 
     0 : Prevent the default {operator}z mapping. You can map to something

--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -20,6 +20,7 @@ func! sneak#init()
   let g:sneak#opt = { 'f_reset' : get(g:, 'sneak#nextprev_f', get(g:, 'sneak#f_reset', 1))
       \ ,'t_reset'      : get(g:, 'sneak#nextprev_t', get(g:, 'sneak#t_reset', 1))
       \ ,'s_next'       : get(g:, 'sneak#s_next', 0)
+      \ ,'preserve_dir' : get(g:, 'sneak#preserve_dir', 0)
       \ ,'textobject_z' : get(g:, 'sneak#textobject_z', 1)
       \ ,'use_ic_scs'   : get(g:, 'sneak#use_ic_scs', 0)
       \ ,'map_netrw'    : get(g:, 'sneak#map_netrw', 1)
@@ -75,8 +76,9 @@ func! sneak#rpt(op, reverse) abort
     return
   endif
 
+  let s:reverse = (a:reverse && !s:st.reverse) || (!a:reverse && s:st.reverse)
   call sneak#to(a:op, s:st.input, s:st.inputlen, v:count1, 1,
-        \ ((a:reverse && !s:st.reverse) || (!a:reverse && s:st.reverse)), s:st.inclusive, 0)
+        \ (g:sneak#opt.preserve_dir ? a:reverse : s:reverse), s:st.inclusive, 0)
 endf
 
 " input:      may be shorter than inputlen if the user pressed <enter> at the prompt.

--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -20,7 +20,7 @@ func! sneak#init()
   let g:sneak#opt = { 'f_reset' : get(g:, 'sneak#nextprev_f', get(g:, 'sneak#f_reset', 1))
       \ ,'t_reset'      : get(g:, 'sneak#nextprev_t', get(g:, 'sneak#t_reset', 1))
       \ ,'s_next'       : get(g:, 'sneak#s_next', 0)
-      \ ,'preserve_dir' : get(g:, 'sneak#preserve_dir', 0)
+      \ ,'absolute_dir' : get(g:, 'sneak#absolute_dir', 0)
       \ ,'textobject_z' : get(g:, 'sneak#textobject_z', 1)
       \ ,'use_ic_scs'   : get(g:, 'sneak#use_ic_scs', 0)
       \ ,'map_netrw'    : get(g:, 'sneak#map_netrw', 1)
@@ -78,7 +78,7 @@ func! sneak#rpt(op, reverse) abort
 
   let s:reverse = (a:reverse && !s:st.reverse) || (!a:reverse && s:st.reverse)
   call sneak#to(a:op, s:st.input, s:st.inputlen, v:count1, 1,
-        \ (g:sneak#opt.preserve_dir ? a:reverse : s:reverse), s:st.inclusive, 0)
+        \ (g:sneak#opt.absolute_dir ? a:reverse : s:reverse), s:st.inclusive, 0)
 endf
 
 " input:      may be shorter than inputlen if the user pressed <enter> at the prompt.

--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -76,9 +76,9 @@ func! sneak#rpt(op, reverse) abort
     return
   endif
 
-  let s:reverse = (a:reverse && !s:st.reverse) || (!a:reverse && s:st.reverse)
+  let l:reverse = (a:reverse && !s:st.reverse) || (!a:reverse && s:st.reverse)
   call sneak#to(a:op, s:st.input, s:st.inputlen, v:count1, 1,
-        \ (g:sneak#opt.absolute_dir ? a:reverse : s:reverse), s:st.inclusive, 0)
+        \ (g:sneak#opt.absolute_dir ? a:reverse : l:reverse), s:st.inclusive, 0)
 endf
 
 " input:      may be shorter than inputlen if the user pressed <enter> at the prompt.

--- a/tests/test.vader
+++ b/tests/test.vader
@@ -542,6 +542,42 @@ Execute (unset clever-s):
   let g:sneak#s_next = 0
   call sneak#init()
 ###########################################################
+# absolute_dir
+
+Execute (init absolute_dir):
+  let g:sneak#absolute_dir = 1
+  call sneak#init()
+
+Given:
+  abcdef abcdef abcdef
+  abcdef abcdef abcdef
+  abcdef abcdef abcdef
+
+Execute (sneak#state() 'reverse' and 'rptreverse'):
+  norm sab
+  Assert sneak#state()['reverse']    == 0
+  Assert sneak#state()['rptreverse'] == 0
+  norm ;
+  Assert sneak#state()['reverse']    == 0
+  Assert sneak#state()['rptreverse'] == 0
+  norm ,
+  Assert sneak#state()['reverse']    == 0
+  Assert sneak#state()['rptreverse'] == 1
+  norm Sab
+  Assert sneak#state()['reverse']    == 1
+  Assert sneak#state()['rptreverse'] == 1
+  norm ;
+  Assert sneak#state()['reverse']    == 1
+  Assert sneak#state()['rptreverse'] == 0
+  norm ,
+  Assert sneak#state()['reverse']    == 1
+  Assert sneak#state()['rptreverse'] == 1
+
+Execute (unset absolute_dir):
+  let g:sneak#absolute_dir = 0
+  call sneak#init()
+
+###########################################################
 
 Given:
   abcdef abcdef abcdef


### PR DESCRIPTION
This would make the ```<Plug>SneakNext``` and ```<Plug>SneakPrevious``` mappings always search forwards or backwards respectively by adding this line to a vimrc:
```vim
let g:sneak#preserve_dir = 1
```
I believe this PR would solve issues #71 and #95.

This PR (like #123) also doesn't add any documentation or tests because I wanted to get your opinion on the naming of the new variable ```preserve_dir``` and, generally, to get any comments you had on it.

Great plugin by the way, probably one of my favorites.