### PR TITLE
Shading towards direction of streak; option to disable syntax clear on streak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# Modifications in this fork
+
+Improved sneak streak coloring.
+- Text is shaded towards direction of streak.
+  - New highlight group is called `SneakStreakShade`
+- Exposed option to toggle whether syntax is cleared on sneak streak
+  - `let sneak#streak_clear_syntax = 0`
+  - Default value of `1` to preserve behavior (could change this)
+
+### Visualization
+With `sneak#streak_clear_syntax = 1` and default Sneak colors
+![default colors](http://i.imgur.com/kZtooAl.gif)
+
+With `sneak#streak_clear_syntax = 0` and custom Sneak colors
+![custom colors](http://i.imgur.com/HKcq8kf.gif)
+
 # sneak.vim :shoe:
 
 Sneak is a minimalist, versatile Vim *motion* plugin that jumps to any location specified by two characters.

--- a/autoload/sneak/hl.vim
+++ b/autoload/sneak/hl.vim
@@ -30,9 +30,8 @@ func! s:init()
     exec "highlight SneakStreakMask guifg=magenta guibg=magenta ctermfg=".magenta." ctermbg=".magenta
   endif
 
-  if 0 == hlID("SneakStreakNormal") || "" == sneak#hl#get("SneakStreakNormal")
-    exec "syntax match SneakStreakNormal '.*'"
-    exec "highlight SneakStreakNormal guifg=gray guibg=NONE ctermfg=gray ctermbg=NONE"
+  if 0 == hlID("SneakStreakShade") || "" == sneak#hl#get("SneakStreakShade")
+    exec "highlight SneakStreakShade guifg=gray guibg=NONE ctermfg=gray ctermbg=NONE"
   endif
 
   if 0 == hlID("SneakPluginScope") || "" == sneak#hl#get("SneakPluginScope")

--- a/autoload/sneak/hl.vim
+++ b/autoload/sneak/hl.vim
@@ -30,6 +30,11 @@ func! s:init()
     exec "highlight SneakStreakMask guifg=magenta guibg=magenta ctermfg=".magenta." ctermbg=".magenta
   endif
 
+  if 0 == hlID("SneakStreakNormal") || "" == sneak#hl#get("SneakStreakNormal")
+    exec "syntax match SneakStreakNormal '.*'"
+    exec "highlight SneakStreakNormal guifg=gray guibg=NONE ctermfg=gray ctermbg=NONE"
+  endif
+
   if 0 == hlID("SneakPluginScope") || "" == sneak#hl#get("SneakPluginScope")
     if &background ==# 'dark'
       highlight SneakPluginScope guifg=black guibg=white ctermfg=black ctermbg=white

--- a/autoload/sneak/streak.vim
+++ b/autoload/sneak/streak.vim
@@ -33,7 +33,13 @@ let g:sneak#target_labels = get(g:, 'sneak#target_labels', "asdfghjkl;qwertyuiop
 
 func! s:placematch(c, pos)
   let s:matchmap[a:c] = a:pos
-  exec "syntax match SneakStreakTarget '\\%".a:pos[0]."l\\%".a:pos[1]."c.' conceal cchar=".a:c
+  let s:matchlines[a:pos[0]]['marker'] = substitute(
+        \ s:matchlines[a:pos[0]]['marker'],
+        \ '\%'.a:pos[1].'c.',
+        \ a:c,
+        \ '')
+  call add(s:matchlines[a:pos[0]]['matches'], matchaddpos('SneakStreakTarget', [a:pos], 11))
+  call add(s:matchlines[a:pos[0]]['matches'], matchaddpos('SneakPluginTarget', [[a:pos[0], a:pos[1], 2]], 10))
 endf
 
 func! s:decorate_statusline() "highlight statusline to indicate streak-mode.
@@ -42,6 +48,15 @@ endf
 
 func! s:restore_statusline() "restore normal statusline highlight.
   highlight! link StatusLine NONE
+endf
+
+func! s:restore_matchlines()
+  for [line_num, line] in items(s:matchlines)
+    keepjumps call setline(line_num, line['orig'])
+    for id in line['matches']
+      silent! call matchdelete(id)
+    endfor
+  endfor
 endf
 
 func! sneak#streak#to(s, v, reverse)
@@ -58,6 +73,8 @@ func! s:do_streak(s, v, reverse) "{{{
   call s:before(a:reverse)
   let search_pattern = (a:s.prefix).(a:s.search).(a:s.get_onscreen_searchpattern(w))
 
+  let s:matchlines = {}
+  let lastline = -1
   let i = 0
   let overflow = [0, 0] "position of the next match (if any) after we have run out of target labels.
   while 1
@@ -74,6 +91,17 @@ func! s:do_streak(s, v, reverse) "{{{
     if i < s:maxmarks
       "TODO: multibyte-aware substring: matchstr('asdfäöü', '.\{4\}\zs.') https://github.com/Lokaltog/vim-easymotion/issues/16#issuecomment-34595066
       let c = strpart(g:sneak#target_labels, i, 1)
+      if p[0] != lastline
+        if lastline != -1
+          keepjumps call setline(lastline, s:matchlines[lastline]['marker'])
+        endif
+        let s:matchlines[p[0]] = {
+              \ 'orig': getline(p[0]),
+              \ 'marker': getline(p[0]),
+              \ 'matches': [],
+              \ }
+        let lastline = p[0]
+      endif
       call s:placematch(c, p)
     else "we have exhausted the target labels; grab the first non-labeled match.
       let overflow = p
@@ -82,6 +110,7 @@ func! s:do_streak(s, v, reverse) "{{{
 
     let i += 1
   endwhile
+  keepjumps call setline(lastline, s:matchlines[lastline]['marker'])
 
   call winrestview(w) | redraw
   let choice = sneak#util#getchar()
@@ -111,7 +140,7 @@ endf "}}}
 func! s:after()
   autocmd! sneak_streak_cleanup * <buffer>
   silent! call matchdelete(w:sneak_cursor_hl)
-  silent! call matchdelete(w:sneak_normal_hl)
+  silent! call matchdelete(w:sneak_shade_hl)
   "remove temporary highlight links
   exec 'hi! link Conceal '.s:orig_hl_conceal
   exec 'hi! link SneakPluginTarget '.s:orig_hl_sneaktarget
@@ -120,6 +149,7 @@ func! s:after()
   silent! let &syntax=s:syntax_orig
   let &concealcursor=s:cc_orig
   let &conceallevel=s:cl_orig
+  call s:restore_matchlines()
   call s:restore_conceal_in_other_windows()
 endf
 
@@ -144,15 +174,17 @@ func! s:before(reverse)
 
   " prevent highlighting in other windows showing the same buffer
   ownsyntax sneak_streak
+  if !g:sneak#opt.clear_syntax
+    let &syntax=&syntax
+  endif
 
   " highlight the cursor location (else the cursor is not visible during getchar())
-  let w:sneak_cursor_hl = matchadd("SneakStreakCursor", '\%#', 11, -1)
+  let w:sneak_cursor_hl = matchadd("SneakStreakCursor", '\%#', 12)
 
   let s:cc_orig=&l:concealcursor | setlocal concealcursor=ncv
   let s:cl_orig=&l:conceallevel  | setlocal conceallevel=2
 
   let s:syntax_orig=&syntax
-  syntax clear
   " this is fast since we cleared syntax, and it allows sneak to work on very long wrapped lines.
   let s:synmaxcol_orig=&synmaxcol | set synmaxcol=0
 
@@ -162,9 +194,10 @@ func! s:before(reverse)
   hi! link Conceal SneakStreakTarget
   "set temporary link to hide the sneak search targets
   hi! link SneakPluginTarget SneakStreakMask
-  "set temporary link to Normal text highlight
-  let shade_match = a:reverse ? '\%'.line('w0').'l\_.*\%#' : '\%#\_.*\%'.line('w$').'l'
-  let w:sneak_normal_hl = matchadd("SneakStreakNormal", shade_match, 9)
+  "shade ignored text in direction of sneak search
+  let w:sneak_shade_hl = matchadd("SneakStreakShade", a:reverse 
+        \ ? '\%'.line('w0').'l\_.*\%#' 
+        \ : '\%#\_.*\%'.line('w$').'l', 9)
 
   call s:disable_conceal_in_other_windows()
   call s:decorate_statusline()

--- a/autoload/sneak/streak.vim
+++ b/autoload/sneak/streak.vim
@@ -55,7 +55,7 @@ endf
 
 func! s:do_streak(s, v, reverse) "{{{
   let w = winsaveview()
-  call s:before()
+  call s:before(a:reverse)
   let search_pattern = (a:s.prefix).(a:s.search).(a:s.get_onscreen_searchpattern(w))
 
   let i = 0
@@ -111,6 +111,7 @@ endf "}}}
 func! s:after()
   autocmd! sneak_streak_cleanup * <buffer>
   silent! call matchdelete(w:sneak_cursor_hl)
+  silent! call matchdelete(w:sneak_normal_hl)
   "remove temporary highlight links
   exec 'hi! link Conceal '.s:orig_hl_conceal
   exec 'hi! link SneakPluginTarget '.s:orig_hl_sneaktarget
@@ -138,7 +139,7 @@ func! s:restore_conceal_in_other_windows()
   endfor
 endf
 
-func! s:before()
+func! s:before(reverse)
   let s:matchmap = {}
 
   " prevent highlighting in other windows showing the same buffer
@@ -161,6 +162,9 @@ func! s:before()
   hi! link Conceal SneakStreakTarget
   "set temporary link to hide the sneak search targets
   hi! link SneakPluginTarget SneakStreakMask
+  "set temporary link to Normal text highlight
+  let shade_match = a:reverse ? '\%'.line('w0').'l\_.*\%#' : '\%#\_.*\%'.line('w$').'l'
+  let w:sneak_normal_hl = matchadd("SneakStreakNormal", shade_match, 9)
 
   call s:disable_conceal_in_other_windows()
   call s:decorate_statusline()

--- a/doc/sneak.txt
+++ b/doc/sneak.txt
@@ -5,17 +5,17 @@
 ==============================================================================
 1. Overview                                                            *sneak*
 
-Sneak provides a way to move quickly and precisely to locations that would 
-be awkward to reach with built-in Vim motions. 
+Sneak provides a way to move quickly and precisely to locations that would
+be awkward to reach with built-in Vim motions.
 
 Sneak is invoked with s (sneak forward) or S (sneak backwards), followed by
 exactly two characters:
 
     s{char}{char}
 
-Thus, you can often reach a target with only 3 keystrokes. Sneak always moves 
+Thus, you can often reach a target with only 3 keystrokes. Sneak always moves
 immediately to the first {char}{char} match. Additional matches are
-highlighted, and you can reach them by pressing ; (similar to the built-in 
+highlighted, and you can reach them by pressing ; (similar to the built-in
 behavior for |f| and |t|).
 
 Sneak has a few other features, but above all, Sneak tries to get out of your
@@ -74,7 +74,7 @@ NORMAL-mode mappings~
     [count]S{char}{char}     | Invoke backwards |sneak-vertical-scope|
     {operator}z{char}{char}  | Perform {operator} from the cursor to the next
                              | occurrence of {char}{char}
-    {operator}Z{char}{char}  | Perform {operator} from the cursor to the 
+    {operator}Z{char}{char}  | Perform {operator} from the cursor to the
                              | previous occurrence of {char}{char}
 
     NOTE: s and S go to the next/previous match only immediately after
@@ -254,8 +254,8 @@ Repeat the operation with dot: |.|
 ------------------------------------------------------------------------------
 3.5 Vertical Scope                                      *sneak-vertical-scope*
 
-Sneak has a unique feature called "vertical scope" search. This is invoked by 
-prefixing a normal Sneak search (`s` or `S`) with a [count]. In that case, 
+Sneak has a unique feature called "vertical scope" search. This is invoked by
+prefixing a normal Sneak search (`s` or `S`) with a [count]. In that case,
 the search is restricted to a column having a width of 2× the [count].
 
 |sneak-vertical-scope| never invokes |sneak-streak-mode|.
@@ -395,6 +395,13 @@ g:sneak#streak_esc = "\<space>"
     Exit |sneak-streak-mode| as if <esc> were pressed.
         https://github.com/justinmk/vim-sneak/issues/122
 
+g:sneak#streak_clear_syntax = 1
+
+    0 : Preserve syntax when entering |sneak-streak-mode|. Text that is not
+        in the direction of |sneak-streak-mode| preserves its highlighting.
+
+    1 : Clear syntax when entering |sneak-streak-mode|.
+
 g:sneak#target_labels = "asdfghjkl;qwertyuiopzxcvbnm/ASDFGHJKL:QWERTYUIOPZXCVBNM?"
 
     List of 1-character "labels" used by streak-mode to decorate the target
@@ -436,6 +443,10 @@ Sneak uses the following highlight groups:
         Decorates the statusline during |sneak-streak-mode|. This only works
         if you use the default |hl-StatusLine| highlight group; it probably
         won't work if you use a statusline plugin like Powerline.
+
+    SneakStreakShade
+        Shades un-matched text towards direction of |sneak-streak-mode|.
+        Makes ignored text less distracting.
 
 There are three ways to override the default colors (listed in order of
 decreasing elegance):

--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -27,7 +27,7 @@ func! sneak#init()
       \ ,'streak'       : get(g:, 'sneak#streak', 0) && (v:version >= 703) && has("conceal")
       \ ,'streak_esc'   : get(g:, 'sneak#streak_esc', "\<space>")
       \ ,'prompt'       : get(g:, 'sneak#prompt', '>')
-      \ ,'clear_syntax' : get(g:, 'sneak#clear_syntax', 1)
+      \ ,'streak_clear_syntax' : get(g:, 'sneak#streak_clear_syntax', 1)
       \ }
 
   for k in ['f', 't'] "if user mapped f/t to Sneak, then disable f/t reset.

--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -27,6 +27,7 @@ func! sneak#init()
       \ ,'streak'       : get(g:, 'sneak#streak', 0) && (v:version >= 703) && has("conceal")
       \ ,'streak_esc'   : get(g:, 'sneak#streak_esc', "\<space>")
       \ ,'prompt'       : get(g:, 'sneak#prompt', '>')
+      \ ,'clear_syntax' : get(g:, 'sneak#clear_syntax', 1)
       \ }
 
   for k in ['f', 't'] "if user mapped f/t to Sneak, then disable f/t reset.


### PR DESCRIPTION
The following is also in the README, so I'll have to remove it before a merge. Let me know.

# Modifications in this fork

Improved sneak streak coloring.
- Text is shaded towards direction of streak.
  - New highlight group is called `SneakStreakShade`
- Exposed option to toggle whether syntax is cleared on sneak streak
  - `let sneak#streak_clear_syntax = 0`
  - Default value of `1` to preserve behavior (could change this)

### Visualization
With `sneak#streak_clear_syntax = 1` and default Sneak colors
![default colors](http://i.imgur.com/kZtooAl.gif)

With `sneak#streak_clear_syntax = 0` and custom Sneak colors
![custom colors](http://i.imgur.com/HKcq8kf.gif)
