### PR TITLE
Move cursor to the right instead of using visual-mode

### DIFF
--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -142,10 +142,6 @@ func! sneak#to(op, input, inputlen, count, repeatmotion, reverse, inclusive, str
     call s:ft_hook()
   endif
 
-  if is_op && 2 != a:inclusive && !a:reverse
-    norm! v
-  endif
-
   let nextchar = searchpos('\_.', 'n'.(s.search_options_no_s))
   let nudge = !a:inclusive && a:repeatmotion && nextchar == s.dosearch('n')
   if nudge
@@ -207,6 +203,12 @@ func! sneak#to(op, input, inputlen, count, repeatmotion, reverse, inclusive, str
   "enter streak-mode iff there are >=2 _additional_ on-screen matches.
   let target = (2 == a:streak || (a:streak && g:sneak#opt.streak && (is_op || s.hasmatches(2)))) && !max(bounds)
         \ ? sneak#streak#to(s, is_v, a:reverse) : ""
+
+  if is_op && 2 != a:inclusive && !a:reverse
+    " VIM doesn't apply the operator on the current character when forward
+    " searching, therefore move the cursor 1 to right in f- and t-like mode.
+    call sneak#util#nudge(1)
+  endif
 
   if is_op || "" != target
     call sneak#hl#removehl()


### PR DESCRIPTION
Instead of using visual-mode to make sure the character the cursor is
currently on gets included, just move the cursor to the right. Fixes
issue #177, because a visual selection is always at least 1 character.
Also makes using operator-pending mode icm with streak-mode look a
little less ugly :)