### PR TITLE
Nudge after label-mode (FKA streak-mode)

### DIFF
--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -159,11 +159,11 @@ func! sneak#to(op, input, inputlen, count, repeatmotion, reverse, inclusive, str
     endif
   endfor
 
-  if nudge && (!is_v || max(matchpos) > 0)
-    call sneak#util#nudge(a:reverse) "undo nudge for t
-  endif
-
   if 0 == max(matchpos)
+    if nudge
+      call sneak#util#nudge(a:reverse) "undo nudge for t
+    endif
+
     let km = empty(&keymap) ? '' : ' ('.&keymap.' keymap)'
     call sneak#util#echo('not found'.(max(bounds) ? printf(km.' (in columns %d-%d): %s', bounds[0], bounds[1], a:input) : km.': '.a:input))
     return
@@ -205,6 +205,10 @@ func! sneak#to(op, input, inputlen, count, repeatmotion, reverse, inclusive, str
   " Operators always invoke streak-mode; also for 3+ on-screen matches.
   let target = (2 == a:streak || (a:streak && g:sneak#opt.streak && (is_op || s.hasmatches(2)))) && !max(bounds)
         \ ? sneak#streak#to(s, is_v, a:reverse) : ""
+
+  if nudge
+    call sneak#util#nudge(a:reverse) "undo nudge for t
+  endif
 
   if is_op && 2 != a:inclusive && !a:reverse
     " f/t operations do not apply to the current character; nudge the cursor.

--- a/tests/test.vader
+++ b/tests/test.vader
@@ -1086,6 +1086,47 @@ Expect:
   ab7cdef ab8cdef ab9cdef ab0cdef ab1cdef ab2cdef
   ab1cdef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
 
+###########################################################
+# test streak mode with exclusive sneak
+
+Execute (mappings for exclusive streak mode):
+  nnoremap <silent> t :<c-u>call sneak#wrap('', 1, 0, 0, 2)<cr>
+  nnoremap <silent> T :<c-u>call sneak#wrap('', 1, 1, 0, 2)<cr>
+  onoremap <silent> t :<c-u>call sneak#wrap(v:operator, 1, 0, 0, 2)<cr>
+  onoremap <silent> T :<c-u>call sneak#wrap(v:operator, 1, 1, 0, 2)<cr>
+
+Do (sneak-streak to correct character with exclusive sneak, forwards, normal [issue #176]):
+  tcax
+
+Expect:
+  ab1cdef ab2cdef abcdef ab4cdef ab5cdef ab6cdef
+  ab7cdef ab8cdef ab9cdef ab0cdef ab1cdef ab2cdef
+  ab1cdef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
+
+Do (sneak-streak to correct character with exclusive sneak, backwards, normal [issue #176]):
+  $Tcsx
+
+Expect:
+  ab1cdef ab2cdef ab3cef ab4cdef ab5cdef ab6cdef
+  ab7cdef ab8cdef ab9cdef ab0cdef ab1cdef ab2cdef
+  ab1cdef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
+
+Do (sneak-streak to correct character with exclusive sneak, forwards, op-pending [issue #176]):
+  wwdtfa
+
+Expect:
+  ab1cdef ab2cdef f ab6cdef
+  ab7cdef ab8cdef ab9cdef ab0cdef ab1cdef ab2cdef
+  ab1cdef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
+
+Do (sneak-streak to correct character with exclusive sneak, backwards, op-pending [issue #176]):
+  5wcTb;X
+
+Expect:
+  ab1cdef ab2cdef ab3cdef abXab6cdef
+  ab7cdef ab8cdef ab9cdef ab0cdef ab1cdef ab2cdef
+  ab1cdef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
+
 Execute (cleanup):
   silent! unmap f
   silent! unmap F


### PR DESCRIPTION
Instead of immediately nudging after finding first result, wait until
the streaking has finished, so exclusive (t-like) mode also works
correctly icm with streaking. Fixes issue #176.
Also loosens the criterion for nudging, fixes issue #179.
