### PR TITLE
Make sure SneakPlugin is defined when clearing it

### DIFF
--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -49,7 +49,9 @@ endf
 
 func! sneak#cancel()
   call sneak#hl#removehl()
-  autocmd! SneakPlugin
+  augroup SneakPlugin
+    autocmd!
+  augroup END
   if maparg('<esc>', 'n') =~# 'sneak#cancel' "teardown temporary <esc> mapping
     silent! unmap <esc>
   endif


### PR DESCRIPTION
I want to add `sneak#cancel()` to my `<C-L>` binding to clear the sneak
highlights without moving the cursor, like I do for `nohlsearch`.  But
if I use that before ever having sneaked, I get this error:

    Error detected while processing function sneak#cancel:
    line    2:
    E216: No such group or event: SneakPlugin

This can be avoided by defining the group while clearing it.