### PR TITLE
Fix default color selection for old Vim versions

### DIFF
--- a/autoload/sneak/hl.vim
+++ b/autoload/sneak/hl.vim
@@ -21,7 +21,10 @@ endf
 
 func! s:default_color(hlgroup, what, mode) abort
   let c = synIDattr(synIDtrans(hlID(a:hlgroup)), a:what, a:mode)
-  return !empty(c) ? c : (a:what ==# 'bg' ? 'magenta' : 'white')
+  if empty(c) || c == -1
+    return a:what ==# 'bg' ? 'magenta' : 'white'
+  endif
+  return c
 endfunc
 
 func! s:init() abort


### PR DESCRIPTION
Before 7.4.1547 getting a cterm highlight attribute that is not set results in the string `-1`.