### PR TITLE
Fix description of `sneak#is_sneaking()`

### DIFF
--- a/doc/sneak.txt
+++ b/doc/sneak.txt
@@ -408,10 +408,12 @@ sneak#wrap(op, inputlen, reverse, inclusive, label)             *sneak#wrap()*
           onoremap <silent> S :<C-U>call sneak#wrap(v:operator,   3, 1, 2, 1)<CR>
 <
 sneak#is_sneaking()                                       *sneak#is_sneaking()*
-        Returns 1 if Sneak is active (matches are highlighted).
-        Returns 0 after the user does anything (which deactivates Sneak and
-        removes the highlight). Useful for changing the behavior of a mapping
-        based on whether Sneak is active.
+        Returns 1 if Sneak is active (Sneak is activated by 2-character Sneak,
+        Sneak repeat motion and 1-character enhanced f/F/t/T).
+        Returns 0 if Sneak is not active (Sneak is deactivated by most user
+        actions that do not activate Sneak).
+        Useful for changing the behavior of a mapping based on whether Sneak is
+        active.
             https://github.com/justinmk/vim-sneak/pull/93
 
         For example you might want <Tab> to go to the next match _only_ while

--- a/doc/sneak.txt
+++ b/doc/sneak.txt
@@ -408,12 +408,9 @@ sneak#wrap(op, inputlen, reverse, inclusive, label)             *sneak#wrap()*
           onoremap <silent> S :<C-U>call sneak#wrap(v:operator,   3, 1, 2, 1)<CR>
 <
 sneak#is_sneaking()                                       *sneak#is_sneaking()*
-        Returns 1 if Sneak is active (Sneak is activated by 2-character Sneak,
-        Sneak repeat motion and 1-character enhanced f/F/t/T).
-        Returns 0 if Sneak is not active (Sneak is deactivated by most user
-        actions that do not activate Sneak).
-        Useful for changing the behavior of a mapping based on whether Sneak is
-        active.
+        Returns 1 if Sneak is active (Most vim-sneak actions activate Sneak).
+        Returns 0 if Sneak is not active (Most other actions deactivate Sneak).
+        Useful for customizations based on whether Sneak is active.
             https://github.com/justinmk/vim-sneak/pull/93
 
         For example you might want <Tab> to go to the next match _only_ while


### PR DESCRIPTION
According to the documentation, `sneak#is_sneaking()` returns 1 if Sneak
is active (matches are highlighted). But Sneak can be active without any
matches being highlighted. This happens for instance after using Sneak
in label mode, or if there is precisely one match in the direction of a
Sneak. It also happens after Sneak has been used in operator pending
mode. Rather than describing possible side effects of Sneak being
active, it is simpler, and arguably more precise, to list those actions
which activate Sneak.

If you think the documentation is already clear, I apologize for the inconvenience!

Attached is a minimal vimrc for testing: [minivimrc.txt](https://github.com/justinmk/vim-sneak/files/1220394/minivimrc.txt)

closes #206