### PR TITLE
Use matchadd() to implement a less obstrusive Streak Mode

### DIFF
--- a/autoload/sneak/label.vim
+++ b/autoload/sneak/label.vim
@@ -100,9 +100,11 @@ func! s:after() abort
   exec 'hi! link Sneak '.s:orig_hl_sneak
   let &l:synmaxcol=s:o_synmaxcol
   " Always clear before restore, in case user has `:syntax off`. #200
-  syntax clear
+  if g:sneak#opt.clear_syntax
+    syntax clear
+    silent! let &l:syntax=s:o_syntax
+  endif
   silent! let &l:foldmethod=s:o_fdm
-  silent! let &l:syntax=s:o_syntax
   " Force Vim to reapply 'spell' (must set 'spelllang'). #110
   let [&l:spell,&l:spelllang]=[s:o_spell,s:o_spelllang]
   let [&l:concealcursor,&l:conceallevel]=[s:o_cocu,s:o_cole]
@@ -134,16 +136,22 @@ func! s:before() abort
   endfor
 
   setlocal nospell concealcursor=ncv conceallevel=2
-  " prevent highlighting in other windows showing the same buffer
-  ownsyntax sneak_label
+
+  if g:sneak#opt.clear_syntax
+    " prevent highlighting in other windows showing the same buffer
+    ownsyntax sneak_label
+  endif
+
   " highlight the cursor location (else the cursor is not visible during getchar())
   let w:sneak_cursor_hl = matchadd("Cursor", '\%#', 11, -1)
   if &l:foldmethod ==# 'syntax' " Avoid broken folds when we clear syntax below.
     setlocal foldmethod=manual
   endif
 
-  syntax clear
-  syn match Comment '.*'
+  if g:sneak#opt.clear_syntax
+    syntax clear
+    syn match Comment '.*'
+  endif
 
   " this is fast since we cleared syntax, and it allows sneak to work on very long wrapped lines.
   setlocal synmaxcol=0

--- a/autoload/sneak/label.vim
+++ b/autoload/sneak/label.vim
@@ -1,15 +1,21 @@
 " NOTES:
 "   problem:  cchar cannot be more than 1 character.
 "   strategy: make fg/bg the same color, then conceal the other char.
-" 
+"
 "   problem:  keyword highlighting always takes priority over conceal.
 "   strategy: syntax clear | [do the conceal] | let &syntax=s:o_syntax
 
 let g:sneak#target_labels = get(g:, 'sneak#target_labels', ";sftunq/SFGHLTUNRMQZ?0")
 
+let s:current_matches = []
+
 func! s:placematch(c, pos) abort
   let s:matchmap[a:c] = a:pos
-  exec "syntax match SneakLabel '\\%".a:pos[0]."l\\%".a:pos[1]."c.' conceal cchar=".a:c
+
+  let pattern = "\\%".a:pos[0]."l\\%".a:pos[1]."c."
+  let m = matchadd('Conceal', pattern, 10, -1, { 'conceal': a:c })
+
+  call add(s:current_matches, m)
 endf
 
 func! sneak#label#to(s, v) abort
@@ -87,6 +93,8 @@ endf "}}}
 func! s:after() abort
   autocmd! sneak_label_cleanup
   silent! call matchdelete(w:sneak_cursor_hl)
+  call map(s:current_matches, 'matchdelete(v:val)')
+  let s:current_matches = []
   "remove temporary highlight links
   exec 'hi! link Conceal '.s:orig_hl_conceal
   exec 'hi! link Sneak '.s:orig_hl_sneak
@@ -135,6 +143,8 @@ func! s:before() abort
   endif
 
   syntax clear
+  syn match Comment '.*'
+
   " this is fast since we cleared syntax, and it allows sneak to work on very long wrapped lines.
   setlocal synmaxcol=0
 

--- a/doc/sneak.txt
+++ b/doc/sneak.txt
@@ -353,6 +353,12 @@ g:sneak#prompt = '>'
 
         Message displayed at the Sneak input prompt.
 
+
+g:sneak#clear_syntax = '0'
+
+        Controls whether the syntax highlighting is kept or not during
+        label-mode. Setting it on will produce an easymotion-like interface.
+
 ------------------------------------------------------------------------------
 Custom Highlighting                                          *sneak-highlight*
 

--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -26,6 +26,7 @@ func! sneak#init()
       \ ,'label'        : get(g:, 'sneak#label', get(g:, 'sneak#streak', 0)) && (v:version >= 703) && has("conceal")
       \ ,'label_esc'    : get(g:, 'sneak#label_esc', get(g:, 'sneak#streak_esc', "\<space>"))
       \ ,'prompt'       : get(g:, 'sneak#prompt', '>')
+      \ ,'clear_syntax' : get(g:, 'sneak#clear_syntax', 0)
       \ }
 
   for k in ['f', 't'] "if user mapped f/t to Sneak, then disable f/t reset.


### PR DESCRIPTION
Fixes #136 

This produces an interface very similar to EasyMotion, with the whole text greyed out and the SneakLabels highlighted.

Let me know if there's anything I can do to get this merged.