### PR TITLE
dot-repeat for 'operatorfunc' (g@)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,22 @@
-VIM = vim -N -u NORC -i NONE --cmd 'set rtp+=tests/vader rtp+=tests/repeat rtp+=$$PWD'
+VIM = vim -N -u NORC -i NONE --cmd 'set rtp+=tests/vim-vader rtp+=tests/vim-repeat rtp+=tests/vim-surround rtp+=$$PWD'
 
-test: tests/vader tests/repeat
+test: tests/vim-vader tests/vim-repeat tests/vim-surround
 	$(VIM) '+Vader! tests/*.vader'
 
 # https://github.com/junegunn/vader.vim/pull/75
-testnvim: tests/vader tests/repeat
+testnvim: tests/vim-vader tests/vim-repeat tests/vim-surround
 	VADER_OUTPUT_FILE=/dev/stderr n$(VIM) --headless '+Vader! tests/*.vader'
 
-testinteractive: tests/vader tests/repeat
+testinteractive: tests/vim-vader tests/vim-repeat tests/vim-surround
 	$(VIM) '+Vader tests/*.vader'
 
-tests/vader:
-	git clone https://github.com/junegunn/vader.vim tests/vader || ( cd tests/vader && git pull --rebase; )
+tests/vim-vader:
+	git clone https://github.com/junegunn/vader.vim tests/vim-vader || ( cd tests/vim-vader && git pull --rebase; )
 
-tests/repeat:
-	git clone https://github.com/tpope/vim-repeat tests/repeat || ( cd tests/repeat && git pull --rebase; )
+tests/vim-repeat:
+	git clone https://github.com/tpope/vim-repeat tests/vim-repeat || ( cd tests/vim-repeat && git pull --rebase; )
 
-.PHONY: test testinteractive
+tests/vim-surround:
+	git clone https://github.com/tpope/vim-surround tests/vim-surround || ( cd tests/vim-surround && git pull --rebase; )
+
+.PHONY: test testnvim testinteractive

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ via `z` (because `s` is taken by surround.vim).
     * Type `2.` to repeat twice.
     * Type `d;` to delete up to the next match.
     * Type `4d;` to delete up to the *fourth* next match.
-* Type `ysz))]` to surround in brackets up to `))`.
-    * Type `;` to go to the next `))`.
+* Type `yszxy]` to [surround] in brackets up to `xy`.
+    * Type `.` to repeat the surround operation.
 * Type `gUz\}` to upper-case the text from the cursor until the next instance
   of the literal text `\}`
     * Type `.` to repeat the `gUz\}` operation.

--- a/autoload/sneak/label.vim
+++ b/autoload/sneak/label.vim
@@ -22,10 +22,10 @@ func! s:placematch(c, pos) abort
   endif
 endf
 
-func! sneak#label#to(s, v) abort
+func! sneak#label#to(s, v, label) abort
   let seq = ""
   while 1
-    let choice = s:do_label(a:s, a:v, a:s._reverse)
+    let choice = s:do_label(a:s, a:v, a:s._reverse, a:label)
     let seq .= choice
     if choice =~# "^\<S-Tab>\\|\<BS>$"
       call a:s.init(a:s._input, a:s._repeatmotion, 1)
@@ -37,7 +37,7 @@ func! sneak#label#to(s, v) abort
   endwhile
 endf
 
-func! s:do_label(s, v, reverse) abort "{{{
+func! s:do_label(s, v, reverse, label) abort "{{{
   let w = winsaveview()
   call s:before()
   let search_pattern = (a:s.prefix).(a:s.search).(a:s.get_onscreen_searchpattern(w))
@@ -68,7 +68,7 @@ func! s:do_label(s, v, reverse) abort "{{{
   endwhile
 
   call winrestview(w) | redraw
-  let choice = sneak#util#getchar()
+  let choice = empty(a:label) ? sneak#util#getchar() : a:label
   call s:after()
 
   let mappedto = maparg(choice, a:v ? 'x' : 'n')

--- a/doc/sneak.txt
+++ b/doc/sneak.txt
@@ -81,6 +81,9 @@ VISUAL-MODE~
     s                        | Go to the [count]th next match (NOTE above)
     S                        | Go to the [count]th previous match (NOTE above)
 
+    NOTE: Z goes backwards in visual-mode, because S is taken by the
+    |surround| plugin).
+
 LABEL-MODE~
     Key Sequence             | Description
     -------------------------|----------------------------------------------
@@ -179,13 +182,6 @@ and |,| were reset by |f| or |t|. This is especially useful for re-invoking
 |sneak-label-mode| (because |;| and |,| never invoke label-mode).
 
 ------------------------------------------------------------------------------
-VISUAL-MODE
-
-`s` works in visual mode the same as normal mode, however to search backwards
-use `Z` (because `S` is taken by the |surround| plugin). `;` and `,` also
-work in visual mode as they do in normal mode.
-
-------------------------------------------------------------------------------
 OPERATIONS
 
 Use `z` for operations (or map to something else: |sneak-custom-mappings|).
@@ -193,8 +189,12 @@ For example, `dzab` deletes from the cursor to the next instance of "ab".
 `dZab` deletes backwards to the previous instance. `czab` `cZab` `yzab` and
 `yZab` also work as expected.
 
-Repeat the operation with dot: |.|
-Note: Requires repeat.vim https://github.com/tpope/vim-repeat
+Repeat the operation with dot |.| (requires repeat.vim
+https://github.com/tpope/vim-repeat).
+
+Note: |.| repeat works correctly with vim-surround (requires Vim 7.4.786), but
+if you undo followed by dot-repeat again, it waits for input.  This bug is not
+related to Sneak, it happens with builtin motions also.
 
 ------------------------------------------------------------------------------
 VERTICAL SCOPE                                          *sneak-vertical-scope*

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
-vader
-repeat
+vim-vader
+vim-repeat
+vim-surround

--- a/tests/test.vader
+++ b/tests/test.vader
@@ -1,5 +1,4 @@
 # vim -N -u NONE -c "set rtp+=~/.vim/bundle/vim-sneak,~/.vim/bundle/vader.vim,~/.vim/bundle/vim-repeat" -c "runtime! plugin/sneak.vim plugin/vader.vim plugin/repeat.vim" -c "Vader ~/.vim/bundle/vim-sneak/tests/test.vader"
-# vim -N -u NONE -c 'set rtp+=~/.vim/bundle/vim-sneak,~/.vim/bundle/vader.vim,~/.vim/bundle/vim-repeat' -c 'runtime! plugin/sneak.vim plugin/vader.vim plugin/repeat.vim' -c 'Vader ~/.vim/bundle/vim-sneak/tests/test.vader'
 #
 # BUG: highlight targets are bogus if &iminsert=1
 # BUG: sneak cannot find ёе: in this text


### PR DESCRIPTION
Use an `OptionSet` handler to remember the current 'operatorfunc' (g@) operation. If the same operation is seen later, repeat the last input instead of waiting for input. This works because 'operatorfunc' (apparently) is _not_ set on dot-repeat. 

This is needed because our `repeat#set()` (provided by the vim-repeat plugin) gets clobbered in some cases (such as vim-surround) where the motion (Sneak) happens in the middle of the operation.

closes #94

Thanks @wilywampa!

