### PR TITLE
doc: link Sneak None instead of Normal for disable highlighting

### DIFF
--- a/doc/sneak.txt
+++ b/doc/sneak.txt
@@ -365,7 +365,7 @@ To customize colors: >
     highlight SneakScope guifg=red guibg=yellow ctermfg=red ctermbg=yellow
 
 To disable highlighting: >
-    highlight link Sneak Normal
+    highlight link Sneak None
     " Needed if a plugin sets the colorscheme dynamically:
     autocmd User SneakLeave highlight clear Sneak
 


### PR DESCRIPTION
`hi link Sneak Normal` overrides the original hightlight of the text on my nvim.