### PR TITLE
Add support for `vscode-neovim`

### DIFF
--- a/autoload/sneak/label.vim
+++ b/autoload/sneak/label.vim
@@ -97,7 +97,7 @@ func! s:do_label(s, v, reverse, label) abort "{{{
           call add(marksPerLine, [p[0], []])
           let rowIndexInMarksArray += 1
         endif
-        call add(marksPerLine[rowIndexInMarksArray][1], [p[1], c])
+        call add(marksPerLine[rowIndexInMarksArray][1], [p[1], c, "magenta"])
       endif
     else  " We have exhausted the target labels; grab the first non-labeled match.
       let overflow = p

--- a/autoload/sneak/util.vim
+++ b/autoload/sneak/util.vim
@@ -104,7 +104,9 @@ endf
 func! sneak#util#removehl() abort
   silent! call matchdelete(w:sneak_hl_id)
   silent! call matchdelete(w:sneak_sc_hl)
-  silent! call VSCodeSetTextDecorations(g:vim_sneak_hl_group_target, [])
+  if (exists('g:vscode'))
+    silent! call VSCodeSetTextDecorations(g:vim_sneak_hl_group_target, [])
+  endif
 endf
 
 " Gets the 'links to' value of the specified highlight group, if any.

--- a/autoload/sneak/util.vim
+++ b/autoload/sneak/util.vim
@@ -134,12 +134,16 @@ func! s:init_hl() abort
   let guifg   = s:default_color('Sneak', 'fg', 'gui')
   let ctermbg = s:default_color('Sneak', 'bg', 'cterm')
   let ctermfg = s:default_color('Sneak', 'fg', 'cterm')
-  exec 'highlight default SneakLabel gui=bold cterm=bold guifg='.guifg.' guibg='.guibg.' ctermfg='.ctermfg.' ctermbg='.ctermbg
+  if !exists('g:vscode')
+    exec 'highlight default SneakLabel gui=bold cterm=bold guifg='.guifg.' guibg='.guibg.' ctermfg='.ctermfg.' ctermbg='.ctermbg
+  endif
 
   let guibg   = s:default_color('SneakLabel', 'bg', 'gui')
   let ctermbg = s:default_color('SneakLabel', 'bg', 'cterm')
   " fg same as bg
-  exec 'highlight default SneakLabelMask guifg='.guibg.' guibg='.guibg.' ctermfg='.ctermbg.' ctermbg='.ctermbg
+  if !exists('g:vscode')
+    exec 'highlight default SneakLabelMask guifg='.guibg.' guibg='.guibg.' ctermfg='.ctermbg.' ctermbg='.ctermbg
+  endif
 endf
 
 augroup sneak_colorscheme  " Re-init on :colorscheme change at runtime. #108

--- a/autoload/sneak/util.vim
+++ b/autoload/sneak/util.vim
@@ -104,6 +104,7 @@ endf
 func! sneak#util#removehl() abort
   silent! call matchdelete(w:sneak_hl_id)
   silent! call matchdelete(w:sneak_sc_hl)
+  silent! call VSCodeSetTextDecorations(g:vim_sneak_hl_group_target, [])
 endf
 
 " Gets the 'links to' value of the specified highlight group, if any.

--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -59,7 +59,9 @@ endfunction
 
 func! sneak#init() abort
   unlockvar g:sneak#opt
-  call sneak#InitHL(g:vim_sneak_hl_group_target, s:target_hl_defaults)
+  if (exists('g:vscode'))
+    call sneak#InitHL(g:vim_sneak_hl_group_target, s:target_hl_defaults)
+  endif
   "options                                 v-- for backwards-compatibility
   let g:sneak#opt = { 'f_reset' : get(g:, 'sneak#nextprev_f', get(g:, 'sneak#f_reset', 1))
       \ ,'t_reset'      : get(g:, 'sneak#nextprev_t', get(g:, 'sneak#t_reset', 1))


### PR DESCRIPTION
Updated PR from: https://github.com/justinmk/vim-sneak/pull/284, just for reference

# Context
1. `vscode-neovim` does not support `conceal` properly when highlighting for now, therefore, when using `let g:sneak#label = 1
` the labels were not shown as expected, instead, the first character of the match is shown always.
2. `vscode-neovim` supports `text decorations` to be shown on top of existing text with the option ` "vscode-neovim.textDecorationsAtTop": true` in vscode's `settings.json`
3. `easymotion` plugin had a similar issue that was solved using `textDecorations` for vscode. See https://github.com/asvetliakov/vscode-neovim#vim-easymotion and [commit adding text decorations](https://github.com/asvetliakov/vim-easymotion/commit/d3c0453b9399f10702f14b487788375f1fb860c6)

https://user-images.githubusercontent.com/5056411/136433077-53bd524c-09e1-49fd-ba71-10d9e5ffbda6.mp4

note 1: all the labels have the same key on them
note 2: you can see the key strokes on the status line at the bottom

# What does this PR do?

It adds support for `vscode-neovim` by adding `text-decorations` just when the user is in vscode

# Evidence

https://user-images.githubusercontent.com/5056411/136434014-5f5ad353-11f3-4c18-b4a5-e1008d4f63de.mp4


