### PR TITLE
fix: use visual mode for operator-pending mode f/t

### DIFF
--- a/plugin/sneak.vim
+++ b/plugin/sneak.vim
@@ -164,6 +164,11 @@ func! sneak#to(op, input, inputlen, count, register, repeatmotion, reverse, incl
     call s:ft_hook()
   endif
 
+  let in_visual = is_op && 2 != a:inclusive && !a:reverse
+  if in_visual
+    norm! v
+  endif
+
   let nextchar = searchpos('\_.', 'n'.(s.search_options_no_s))
   let nudge = !a:inclusive && a:repeatmotion && nextchar == s.dosearch('n')
   if nudge
@@ -180,6 +185,9 @@ func! sneak#to(op, input, inputlen, count, register, repeatmotion, reverse, incl
   endfor
 
   if 0 == max(matchpos)
+    if in_visual
+      exe "norm! \<esc>"
+    endif
     if nudge
       call sneak#util#nudge(a:reverse) "undo nudge for t
     endif
@@ -230,11 +238,6 @@ func! sneak#to(op, input, inputlen, count, register, repeatmotion, reverse, incl
 
   if nudge
     call sneak#util#nudge(a:reverse) "undo nudge for t
-  endif
-
-  if is_op && 2 != a:inclusive && !a:reverse
-    " f/t operations do not apply to the current character; nudge the cursor.
-    call sneak#util#nudge(1)
   endif
 
   if is_op || '' != target


### PR DESCRIPTION
f1eb049319bffdda94c5cfeb5c40b603ee9e529f (fix for #177) broke
operator-pending mode f when the target is on eol/eof (#291). Revert
that commit in order to fix #291, and introduce an alternative fix for
 #177: exit visual mode if target is not found.

Fixes #291, #177