### PR TITLE
label-mode: replace conceal with virtual text in nvim ≥ 0.5

### DIFF
--- a/autoload/sneak/label.vim
+++ b/autoload/sneak/label.vim
@@ -1,13 +1,9 @@
 " NOTES:
 "   problem:  cchar cannot be more than 1 character.
 "   strategy: make fg/bg the same color, then conceal the other char.
-"
-"   problem:  [before 7.4.792] keyword highlight takes priority over conceal.
-"   strategy: syntax clear | [do the conceal] | let &syntax=s:o_syntax
 
 let g:sneak#target_labels = get(g:, 'sneak#target_labels', ";sftunq/SFGHLTUNRMQZ?0")
 
-let s:clear_syntax = !has('patch-7.4.792')
 let s:matchmap = {}
 let s:match_ids = []
 let s:orig_conceal_matches = []
@@ -25,12 +21,8 @@ endif
 func! s:placematch(c, pos) abort
   let s:matchmap[a:c] = a:pos
   let pat = '\%'.a:pos[0].'l\%'.a:pos[1].'c.'
-  if s:clear_syntax
-    exec "syntax match SneakLabel '".pat."' conceal cchar=".a:c
-  else
-    let id = matchadd('Conceal', pat, 999, -1, { 'conceal': a:c })
-    call add(s:match_ids, id)
-  endif
+  let id = matchadd('Conceal', pat, 999, -1, { 'conceal': a:c })
+  call add(s:match_ids, id)
 endf
 
 func! s:save_conceal_matches() abort
@@ -134,17 +126,6 @@ func! s:after() abort
   call s:restore_conceal_matches()
   exec 'hi! link Sneak '.s:orig_hl_sneak
 
-  if s:clear_syntax
-    let &l:synmaxcol=s:o_synmaxcol
-    " Always clear before restore, in case user has `:syntax off`. #200
-    syntax clear
-    silent! let &l:foldmethod=s:o_fdm
-    silent! let &l:syntax=s:o_syntax
-    " Force Vim to reapply 'spell' (must set 'spelllang'). #110
-    let [&l:spell,&l:spelllang]=[s:o_spell,s:o_spelllang]
-    call s:restore_conceal_in_other_windows()
-  endif
-
   let [&l:concealcursor,&l:conceallevel]=[s:o_cocu,s:o_cole]
 endf
 
@@ -168,7 +149,7 @@ endf
 
 func! s:before() abort
   let s:matchmap = {}
-  for o in ['spell', 'spelllang', 'cocu', 'cole', 'fdm', 'synmaxcol', 'syntax']
+  for o in ['cocu', 'cole']
     exe 'let s:o_'.o.'=&l:'.o
   endfor
 
@@ -176,20 +157,6 @@ func! s:before() abort
 
   " Highlight the cursor location (because cursor is hidden during getchar()).
   let s:sneak_cursor_hl = matchadd("SneakScope", '\%#', 11, -1)
-
-  if s:clear_syntax
-    setlocal nospell
-    " Prevent highlighting in other windows showing the same buffer.
-    ownsyntax sneak_label
-    " Avoid broken folds when we clear syntax below.
-    if &l:foldmethod ==# 'syntax'
-      setlocal foldmethod=manual
-    endif
-    syntax clear
-    " This is fast because we cleared syntax.  Allows Sneak to work on very long wrapped lines.
-    setlocal synmaxcol=0
-    call s:disable_conceal_in_other_windows()
-  endif
 
   let s:orig_hl_conceal = sneak#util#links_to('Conceal')
   call s:save_conceal_matches()

--- a/lua/sneak.lua
+++ b/lua/sneak.lua
@@ -1,0 +1,43 @@
+local M = {}
+
+local ns = vim.api.nvim_create_namespace('sneak')
+
+local matches
+
+function M.before()
+  matches = {}
+end
+
+function M.placematch(c, row, col)
+  matches[#matches+1] = { c, row, col }
+end
+
+function M.after()
+  matches = nil
+end
+
+function M.init()
+  vim.api.nvim_set_decoration_provider(ns, {
+    on_start = function(_, _)
+      if not matches then
+        return false
+      end
+    end,
+    on_win = function(_, win, _, _, _)
+      if win ~= vim.api.nvim_get_current_win() then
+        return false
+      end
+      for _, m in ipairs(matches) do
+        local c, row, col = unpack(m)
+        vim.api.nvim_buf_set_extmark(0, ns, row, col, {
+          priority = 1000,
+          virt_text = { {c, 'SneakLabel'} },
+          virt_text_pos = 'overlay',
+          ephemeral = true,
+        })
+      end
+    end
+  })
+end
+
+return M


### PR DESCRIPTION
* label-mode: remove workaround for old vim bug
  * This is not necessary. But 7.4.792 dates back to 2015, so I think it's fine to remove. 
* label-mode: replace conceal with virtual text in nvim ≥ 0.5 