### PR TITLE
fix: `s<c1><Enter>` makes hl-SneakCurrent too long

### DIFF
--- a/autoload/sneak.vim
+++ b/autoload/sneak.vim
@@ -191,7 +191,7 @@ func! sneak#to(op, input, inputlen, count, register, repeatmotion, reverse, incl
 
   let matchlen = sneak#util#strlen(a:input)
   if matchlen > 1
-      let w:sneak_cur_hl = matchadd('SneakCurrent', '\%#.\{'.matchlen.'}')
+    let w:sneak_cur_hl = matchadd('SneakCurrent', '\%#.\{'.matchlen.'}')
   endif
 
   " Clear with <esc>. Use a funny mapping to avoid false positives. #287


### PR DESCRIPTION
Followup to fix a mistake in #310

I only recently learned that you can cut the match shorter using `<Enter>`, in which case the `SneakCurrent` hl group is too long.

```
    s{char}<Enter>           | Go to the next occurrence of {char}
    S{char}<Enter>           | Go to the previous occurrence of {char}
```

Here's a simple fix for that.