### PR TITLE
fix: do not set `'<` `'>` marks on `df`

### DIFF
--- a/autoload/sneak.vim
+++ b/autoload/sneak.vim
@@ -231,13 +231,16 @@ func! sneak#to(op, input, inputlen, count, register, repeatmotion, reverse, incl
       call sneak#util#nudge(0)
     else
       " f edge case targeting EOL/EOB
+      let s:save_virtualedit = &virtualedit
       if 1 == a:inclusive && virtcol('.') == virtcol('$') - 1 && &virtualedit !~# 'onemore'
-        let s:save_virtualedit = &virtualedit
         let &virtualedit = 'onemore'
-        autocmd CursorMoved * ++once let &virtualedit = s:save_virtualedit
       endif
       " nudge right but do not wrap on EOL: go beyond EOL on virtual column if necessary
       exec 'norm! l'
+      " restore virtualedit
+      if has('lambda') && exists('*execute')
+        call timer_start(0, {-> execute('let &virtualedit=s:save_virtualedit')})
+      endif
     endif
   endif
 

--- a/autoload/sneak.vim
+++ b/autoload/sneak.vim
@@ -227,20 +227,20 @@ func! sneak#to(op, input, inputlen, count, register, repeatmotion, reverse, incl
   endif
 
   if is_op && 2 != a:inclusive && !a:reverse
+    " o_v flips forward f/t to exclusive
     if mode(1) ==# 'nov'
       call sneak#util#nudge(0)
     else
       " f edge case targeting EOL/EOB
-      let s:save_virtualedit = &virtualedit
       if 1 == a:inclusive && virtcol('.') == virtcol('$') - 1 && &virtualedit !~# 'onemore'
+        let s:save_virtualedit = &virtualedit
         let &virtualedit = 'onemore'
+        if has('lambda') && exists('*execute')
+          call timer_start(0, {-> execute('let &virtualedit=s:save_virtualedit')})
+        endif
       endif
       " nudge right but do not wrap on EOL: go beyond EOL on virtual column if necessary
       exec 'norm! l'
-      " restore virtualedit
-      if has('lambda') && exists('*execute')
-        call timer_start(0, {-> execute('let &virtualedit=s:save_virtualedit')})
-      endif
     endif
   endif
 

--- a/autoload/sneak.vim
+++ b/autoload/sneak.vim
@@ -231,10 +231,7 @@ func! sneak#to(op, input, inputlen, count, register, repeatmotion, reverse, incl
     if 1 == a:inclusive && virtcol('.') == virtcol('$') - 1
       let s:save_virtualedit = &virtualedit
       let &virtualedit = 'onemore'
-      augroup sneak_restore_virtualedit
-        autocmd!
-        autocmd CursorMoved,CmdlineEnter * ++once let &virtualedit = s:save_virtualedit
-      augroup END
+      autocmd CursorMoved * ++once let &virtualedit = s:save_virtualedit
     endif
     " nudge right but do not wrap on EOL: go beyond EOL on virtual column if necessary
     exec 'norm! l'

--- a/autoload/sneak.vim
+++ b/autoload/sneak.vim
@@ -233,7 +233,7 @@ func! sneak#to(op, input, inputlen, count, register, repeatmotion, reverse, incl
       let &virtualedit = 'onemore'
       augroup sneak_restore_virtualedit
         autocmd!
-        autocmd CursorMoved * ++once let &virtualedit = s:save_virtualedit
+        autocmd CursorMoved,CmdlineEnter * ++once let &virtualedit = s:save_virtualedit
       augroup END
     endif
     " nudge right but do not wrap on EOL: go beyond EOL on virtual column if necessary

--- a/autoload/sneak.vim
+++ b/autoload/sneak.vim
@@ -232,12 +232,11 @@ func! sneak#to(op, input, inputlen, count, register, repeatmotion, reverse, incl
       call sneak#util#nudge(0)
     else
       " f edge case targeting EOL/EOB
-      if 1 == a:inclusive && virtcol('.') == virtcol('$') - 1 && &virtualedit !~# 'onemore'
+      let vim_compat = has('lambda') && exists('*execute') " required for timer_start
+      if 1 == a:inclusive && virtcol('.') == virtcol('$') - 1 && &virtualedit !~# 'onemore' && vim_compat
         let s:save_virtualedit = &virtualedit
         let &virtualedit = 'onemore'
-        if has('lambda') && exists('*execute')
-          call timer_start(0, {-> execute('let &virtualedit=s:save_virtualedit')})
-        endif
+        call timer_start(0, {-> execute('let &virtualedit=s:save_virtualedit')})
       endif
       " nudge right but do not wrap on EOL: go beyond EOL on virtual column if necessary
       exec 'norm! l'

--- a/autoload/sneak.vim
+++ b/autoload/sneak.vim
@@ -228,7 +228,7 @@ func! sneak#to(op, input, inputlen, count, register, repeatmotion, reverse, incl
 
   if is_op && 2 != a:inclusive && !a:reverse
     " f edge case targeting EOL/EOB
-    if 1 == a:inclusive && virtcol('.') == virtcol('$') - 1
+    if 1 == a:inclusive && virtcol('.') == virtcol('$') - 1 && &virtualedit !~# 'onemore'
       let s:save_virtualedit = &virtualedit
       let &virtualedit = 'onemore'
       autocmd CursorMoved * ++once let &virtualedit = s:save_virtualedit

--- a/autoload/sneak.vim
+++ b/autoload/sneak.vim
@@ -227,14 +227,18 @@ func! sneak#to(op, input, inputlen, count, register, repeatmotion, reverse, incl
   endif
 
   if is_op && 2 != a:inclusive && !a:reverse
-    " f edge case targeting EOL/EOB
-    if 1 == a:inclusive && virtcol('.') == virtcol('$') - 1 && &virtualedit !~# 'onemore'
-      let s:save_virtualedit = &virtualedit
-      let &virtualedit = 'onemore'
-      autocmd CursorMoved * ++once let &virtualedit = s:save_virtualedit
+    if mode(1) ==# 'nov'
+      call sneak#util#nudge(0)
+    else
+      " f edge case targeting EOL/EOB
+      if 1 == a:inclusive && virtcol('.') == virtcol('$') - 1 && &virtualedit !~# 'onemore'
+        let s:save_virtualedit = &virtualedit
+        let &virtualedit = 'onemore'
+        autocmd CursorMoved * ++once let &virtualedit = s:save_virtualedit
+      endif
+      " nudge right but do not wrap on EOL: go beyond EOL on virtual column if necessary
+      exec 'norm! l'
     endif
-    " nudge right but do not wrap on EOL: go beyond EOL on virtual column if necessary
-    exec 'norm! l'
   endif
 
   if is_op || '' != target

--- a/tests/test.vader
+++ b/tests/test.vader
@@ -1370,7 +1370,7 @@ Expect:
   
 
 # Here it deletes as linewise because of :h d-special
-# (Help tag only exists in Vim)
+# https://github.com/vim/vim/commit/22105fd1fe0dcfe993b5c04c6ebe017a626116e3
 Do(df til last character in another line. #291 #228):
   jdff
   :\<C-U>doautocmd CursorMoved\<CR>

--- a/tests/test.vader
+++ b/tests/test.vader
@@ -1369,8 +1369,8 @@ Expect:
   2ghi 2jkl
   
 
-" Here it deletes as linewise because of :h d-special
-" (Help tag only exists in Vim)
+# Here it deletes as linewise because of :h d-special
+# (Help tag only exists in Vim)
 Do(df til last character in another line. #291 #228):
   jdff
   :\<C-U>doautocmd CursorMoved\<CR>

--- a/tests/test.vader
+++ b/tests/test.vader
@@ -1346,8 +1346,10 @@ Given:
   2ghi 2jkl
   2mno 2pqr
 
+# Extra doautocmds for when virtualedit=onemore is restored #321
 Do(df til last character in the line. #291 #228):
   dff
+  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   
   1ghi 1jkl
@@ -1358,6 +1360,7 @@ Expect:
 
 Do(df til last character in the last buffer line. #291 #228):
   Gdfr
+  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc 1def
   1ghi 1jkl
@@ -1366,16 +1369,19 @@ Expect:
   2ghi 2jkl
   
 
+" Here it deletes as linewise because of :h d-special
+" (Help tag only exists in Vim)
 Do(df til last character in another line. #291 #228):
-  jwdff
+  jdff
+  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc 1def
-  1ghi 
   2ghi 2jkl
   2mno 2pqr
 
 Do(df til EOB from another line. #291 #228):
   3jldfr
+  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc 1def
   1ghi 1jkl
@@ -1383,35 +1389,48 @@ Expect:
   2
 
 Do(df til last character in the line, ;-repeat. #291 #228):
-  dffd;
+  Wdff
+  :\<C-U>doautocmd CursorMoved\<CR>
+  d;
+  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
-  
+  1abc
   2ghi 2jkl
   2mno 2pqr
 
 Do(df til last character in the line, Enter-repeat. #291 #228):
-  dffdf\<Enter>
+  Wdff
+  :\<C-U>doautocmd CursorMoved\<CR>
+  df\<Enter>
+  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
-  
+  1abc
   2ghi 2jkl
   2mno 2pqr
 
 Do(df til last character in the line, dot repeat. #291 #228):
-  dff
+  Wdff
   :\<C-U>doautocmd CursorMoved\<CR>
   .
+  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
-  
+  1abc
   2ghi 2jkl
   2mno 2pqr
 
 Do(df ;-repeat reaching EOB. #291 #228):
-  Wdfrd;
+  Wdfr
+  :\<C-U>doautocmd CursorMoved\<CR>
+  d;
+  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc
 
 Do(df Enter-repeat reaching EOB. #291 #228):
-  Wdfrdf\<Enter>
+  Wdfr
+  :\<C-U>doautocmd CursorMoved\<CR>
+  df\<Enter>
+  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc
 
@@ -1419,6 +1438,7 @@ Do(df dot repeat reaching EOB. #291 #228):
   Wdfr
   :\<C-U>doautocmd CursorMoved\<CR>
   .
+  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc
 

--- a/tests/test.vader
+++ b/tests/test.vader
@@ -1346,10 +1346,8 @@ Given:
   2ghi 2jkl
   2mno 2pqr
 
-# Extra doautocmds for when virtualedit=onemore is restored #321
 Do(df til last character in the line. #291 #228):
   dff
-  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   
   1ghi 1jkl
@@ -1360,7 +1358,6 @@ Expect:
 
 Do(df til last character in the last buffer line. #291 #228):
   Gdfr
-  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc 1def
   1ghi 1jkl
@@ -1373,7 +1370,6 @@ Expect:
 # https://github.com/vim/vim/commit/22105fd1fe0dcfe993b5c04c6ebe017a626116e3
 Do(df til last character in another line. #291 #228):
   jdff
-  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc 1def
   2ghi 2jkl
@@ -1381,7 +1377,6 @@ Expect:
 
 Do(df til EOB from another line. #291 #228):
   3jldfr
-  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc 1def
   1ghi 1jkl
@@ -1390,9 +1385,8 @@ Expect:
 
 Do(df til last character in the line, ;-repeat. #291 #228):
   Wdff
-  :\<C-U>doautocmd CursorMoved\<CR>
+  :sleep 1m\<cr>
   d;
-  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc
   2ghi 2jkl
@@ -1400,9 +1394,8 @@ Expect:
 
 Do(df til last character in the line, Enter-repeat. #291 #228):
   Wdff
-  :\<C-U>doautocmd CursorMoved\<CR>
+  :sleep 1m\<cr>
   df\<Enter>
-  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc
   2ghi 2jkl
@@ -1411,8 +1404,8 @@ Expect:
 Do(df til last character in the line, dot repeat. #291 #228):
   Wdff
   :\<C-U>doautocmd CursorMoved\<CR>
+  :sleep 1m\<cr>
   .
-  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc
   2ghi 2jkl
@@ -1420,25 +1413,23 @@ Expect:
 
 Do(df ;-repeat reaching EOB. #291 #228):
   Wdfr
-  :\<C-U>doautocmd CursorMoved\<CR>
+  :sleep 1m\<cr>
   d;
-  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc
 
 Do(df Enter-repeat reaching EOB. #291 #228):
   Wdfr
-  :\<C-U>doautocmd CursorMoved\<CR>
+  :sleep 1m\<cr>
   df\<Enter>
-  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc
 
 Do(df dot repeat reaching EOB. #291 #228):
   Wdfr
   :\<C-U>doautocmd CursorMoved\<CR>
+  :sleep 1m\<cr>
   .
-  :\<C-U>doautocmd CursorMoved\<CR>
 Expect:
   1abc
 

--- a/tests/test.vader
+++ b/tests/test.vader
@@ -1296,17 +1296,36 @@ Expect:
   ab7cdef ab8cdef ab9cdef ab0cdef ab1cdef ab2cdef
   ab1cdef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
 
-Do:
+Do (exclusive f-delete forward):
   dvfe
-Expect (exclusive f-delete forward):
+Expect:
   ef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
   ab7cdef ab8cdef ab9cdef ab0cdef ab1cdef ab2cdef
   ab1cdef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
 
-Do:
+Do (exclusive t-delete forward):
   dvte
-Expect (exclusive t-delete forward):
+Expect:
   def ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
+  ab7cdef ab8cdef ab9cdef ab0cdef ab1cdef ab2cdef
+  ab1cdef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
+
+# Note: o_v doesn't work in dot repeats in general
+Do (exclusive f-delete forward, dot repeat):
+  dvfe
+  :\<C-U>doautocmd CursorMoved\<CR>
+  .
+Expect (FIXME dot repeat retains v flip to exclusive):
+  ef ab3cdef ab4cdef ab5cdef ab6cdef
+  ab7cdef ab8cdef ab9cdef ab0cdef ab1cdef ab2cdef
+  ab1cdef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
+
+Do (exclusive t-delete forward, dot repeat):
+  dvte
+  :\<C-U>doautocmd CursorMoved\<CR>
+  l.
+Expect (FIXME dot repeat retains v flip to exclusive):
+  ddef ab3cdef ab4cdef ab5cdef ab6cdef
   ab7cdef ab8cdef ab9cdef ab0cdef ab1cdef ab2cdef
   ab1cdef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
 
@@ -1346,7 +1365,7 @@ Given:
   2ghi 2jkl
   2mno 2pqr
 
-Do(df til last character in the line. #291 #228):
+Do (df til last character in the line. #291 #228):
   dff
 Expect:
   
@@ -1356,7 +1375,7 @@ Expect:
   2ghi 2jkl
   2mno 2pqr
 
-Do(df til last character in the last buffer line. #291 #228):
+Do (df til last character in the last buffer line. #291 #228):
   Gdfr
 Expect:
   1abc 1def
@@ -1368,14 +1387,14 @@ Expect:
 
 # Here it deletes as linewise because of :h d-special
 # https://github.com/vim/vim/commit/22105fd1fe0dcfe993b5c04c6ebe017a626116e3
-Do(df til last character in another line. #291 #228):
+Do (df til last character in another line. #291 #228):
   jdff
 Expect:
   1abc 1def
   2ghi 2jkl
   2mno 2pqr
 
-Do(df til EOB from another line. #291 #228):
+Do (df til EOB from another line. #291 #228):
   3jldfr
 Expect:
   1abc 1def
@@ -1383,7 +1402,7 @@ Expect:
   1mno 1pqr
   2
 
-Do(df til last character in the line, ;-repeat. #291 #228):
+Do (df til last character in the line, ;-repeat. #291 #228):
   Wdff
   :sleep 1m\<cr>
   d;
@@ -1392,7 +1411,7 @@ Expect:
   2ghi 2jkl
   2mno 2pqr
 
-Do(df til last character in the line, Enter-repeat. #291 #228):
+Do (df til last character in the line, Enter-repeat. #291 #228):
   Wdff
   :sleep 1m\<cr>
   df\<Enter>
@@ -1401,7 +1420,7 @@ Expect:
   2ghi 2jkl
   2mno 2pqr
 
-Do(df til last character in the line, dot repeat. #291 #228):
+Do (df til last character in the line, dot repeat. #291 #228):
   Wdff
   :\<C-U>doautocmd CursorMoved\<CR>
   :sleep 1m\<cr>
@@ -1411,21 +1430,21 @@ Expect:
   2ghi 2jkl
   2mno 2pqr
 
-Do(df ;-repeat reaching EOB. #291 #228):
+Do (df ;-repeat reaching EOB. #291 #228):
   Wdfr
   :sleep 1m\<cr>
   d;
 Expect:
   1abc
 
-Do(df Enter-repeat reaching EOB. #291 #228):
+Do (df Enter-repeat reaching EOB. #291 #228):
   Wdfr
   :sleep 1m\<cr>
   df\<Enter>
 Expect:
   1abc
 
-Do(df dot repeat reaching EOB. #291 #228):
+Do (df dot repeat reaching EOB. #291 #228):
   Wdfr
   :\<C-U>doautocmd CursorMoved\<CR>
   :sleep 1m\<cr>

--- a/tests/test.vader
+++ b/tests/test.vader
@@ -1298,14 +1298,14 @@ Expect:
 
 Do:
   dvfe
-Expect (FIXME exclusive f-delete forward):
+Expect (exclusive f-delete forward):
   ef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
   ab7cdef ab8cdef ab9cdef ab0cdef ab1cdef ab2cdef
   ab1cdef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
 
 Do:
   dvte
-Expect (FIXME exclusive t-delete forward):
+Expect (exclusive t-delete forward):
   def ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef
   ab7cdef ab8cdef ab9cdef ab0cdef ab1cdef ab2cdef
   ab1cdef ab2cdef ab3cdef ab4cdef ab5cdef ab6cdef


### PR DESCRIPTION
Resolves: #321 
Related: #291, #228

An alternative fix for `df` targeting EOL/EOB (last character in a line):

Replaces visual mode solution from https://github.com/justinmk/vim-sneak/commit/6607043c43e7270e78981b009f15a170e7962a6f with `virtualedit=onemore` solution from https://github.com/justinmk/vim-sneak/issues/228#issuecomment-849735392